### PR TITLE
Add Material 3 preview theme and toolbar styling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,6 +134,14 @@ android {
             manifestPlaceholders["appIcon"] = "@mipmap/ic_blueowl"
             manifestPlaceholders["appIconRound"] = "@mipmap/ic_blueowl"
         }
+        create("m3preview") {
+            applicationId = "info.nightscout.androidaps.m3preview"
+            dimension = "standard"
+            resValue("string", "app_name", "AAPS M3 Preview")
+            versionName = Versions.appVersion + "-m3preview"
+            manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher"
+            manifestPlaceholders["appIconRound"] = "@mipmap/ic_launcher_round"
+        }
     }
 
     useLibrary("org.apache.http.legacy")

--- a/app/src/m3preview/AndroidManifest.xml
+++ b/app/src/m3preview/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:theme="@style/AppTheme.Launcher.Material3"
+        tools:replace="android:theme">
+        <activity
+            android:name="app.aaps.MainActivity"
+            android:theme="@style/AppTheme.Material3Overlay.NoActionBar"
+            tools:replace="android:theme" />
+    </application>
+
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
         <activity
             android:name="app.aaps.MainActivity"
             android:exported="true"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.Material3Overlay.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -38,6 +38,7 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:elevation="2dp"
+        style="@style/Widget.AAPS.Toolbar"
         app:contentInsetEndWithActions="48dp"
         app:contentInsetStartWithNavigation="48dp">
 

--- a/core/ui/src/main/res/values-night/styles.xml
+++ b/core/ui/src/main/res/values-night/styles.xml
@@ -375,15 +375,15 @@
     </style>
 
     <!-- Alert Dialogs -->
-    <style name="DialogTheme" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
+    <style name="DialogTheme" parent="DialogTheme.Material3">
         <item name="colorSurface">#212121</item> <!-- workaround; color compensated elevation -->
         <item name="buttonBarNegativeButtonStyle">@style/DialogOkCancelButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/DialogOkCancelButtonStyle</item>
         <item name="buttonBarNeutralButtonStyle">@style/DialogOkCancelButtonStyle</item>
     </style>
 
-    <style name="DialogOkCancelButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
-        <item name="android:textColor">@color/okButtonText</item>
+    <style name="DialogOkCancelButtonStyle" parent="Widget.Material3.Button.TextButton.Dialog">
+        <item name="android:textColor">?attr/colorPrimary</item>
     </style>
 
     <style name="AppThemeWarningDialog" parent="DialogTheme">

--- a/core/ui/src/main/res/values-night/theme_m3.xml
+++ b/core/ui/src/main/res/values-night/theme_m3.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.AAPS.Material3" parent="Theme.Material3.DayNight">
+        <item name="colorPrimary">@color/aaps_theme_dark_primary</item>
+        <item name="colorOnPrimary">@color/aaps_theme_dark_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/aaps_theme_dark_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/aaps_theme_dark_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/aaps_theme_dark_secondary</item>
+        <item name="colorOnSecondary">@color/aaps_theme_dark_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/aaps_theme_dark_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/aaps_theme_dark_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/aaps_theme_dark_tertiary</item>
+        <item name="colorOnTertiary">@color/aaps_theme_dark_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/aaps_theme_dark_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/aaps_theme_dark_onTertiaryContainer</item>
+        <item name="colorError">@color/aaps_theme_dark_error</item>
+        <item name="colorOnError">@color/aaps_theme_dark_onError</item>
+        <item name="colorErrorContainer">@color/aaps_theme_dark_errorContainer</item>
+        <item name="colorOnErrorContainer">@color/aaps_theme_dark_onErrorContainer</item>
+        <item name="colorBackground">@color/aaps_theme_dark_background</item>
+        <item name="colorOnBackground">@color/aaps_theme_dark_onBackground</item>
+        <item name="android:colorBackground">@color/aaps_theme_dark_background</item>
+        <item name="colorSurface">@color/aaps_theme_dark_surface</item>
+        <item name="colorOnSurface">@color/aaps_theme_dark_onSurface</item>
+        <item name="colorSurfaceVariant">@color/aaps_theme_dark_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/aaps_theme_dark_onSurfaceVariant</item>
+        <item name="colorOutline">@color/aaps_theme_dark_outline</item>
+        <item name="colorInverseSurface">@color/aaps_theme_dark_inverseSurface</item>
+        <item name="colorInverseOnSurface">@color/aaps_theme_dark_inverseOnSurface</item>
+        <item name="colorPrimaryInverse">@color/aaps_theme_dark_primaryInverse</item>
+        <item name="android:windowBackground">@color/aaps_theme_dark_background</item>
+        <item name="toolbarStyle">@style/Widget.AAPS.Toolbar</item>
+        <item name="materialToolbarStyle">@style/Widget.AAPS.Toolbar</item>
+        <item name="materialAlertDialogTheme">@style/DialogTheme.Material3</item>
+        <item name="android:alertDialogTheme">@style/DialogTheme.Material3</item>
+        <item name="alertDialogTheme">@style/DialogTheme.Material3</item>
+    </style>
+
+    <style name="Theme.AAPS.Material3.NoActionBar" parent="Theme.AAPS.Material3">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="ThemeOverlay.AAPS.Material3" parent="ThemeOverlay.Material3">
+        <item name="colorPrimary">@color/aaps_theme_dark_primary</item>
+        <item name="colorOnPrimary">@color/aaps_theme_dark_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/aaps_theme_dark_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/aaps_theme_dark_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/aaps_theme_dark_secondary</item>
+        <item name="colorOnSecondary">@color/aaps_theme_dark_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/aaps_theme_dark_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/aaps_theme_dark_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/aaps_theme_dark_tertiary</item>
+        <item name="colorOnTertiary">@color/aaps_theme_dark_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/aaps_theme_dark_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/aaps_theme_dark_onTertiaryContainer</item>
+        <item name="colorError">@color/aaps_theme_dark_error</item>
+        <item name="colorOnError">@color/aaps_theme_dark_onError</item>
+        <item name="colorErrorContainer">@color/aaps_theme_dark_errorContainer</item>
+        <item name="colorOnErrorContainer">@color/aaps_theme_dark_onErrorContainer</item>
+        <item name="colorBackground">@color/aaps_theme_dark_background</item>
+        <item name="colorOnBackground">@color/aaps_theme_dark_onBackground</item>
+        <item name="colorSurface">@color/aaps_theme_dark_surface</item>
+        <item name="colorOnSurface">@color/aaps_theme_dark_onSurface</item>
+        <item name="colorSurfaceVariant">@color/aaps_theme_dark_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/aaps_theme_dark_onSurfaceVariant</item>
+        <item name="colorOutline">@color/aaps_theme_dark_outline</item>
+        <item name="colorInverseSurface">@color/aaps_theme_dark_inverseSurface</item>
+        <item name="colorInverseOnSurface">@color/aaps_theme_dark_inverseOnSurface</item>
+        <item name="colorPrimaryInverse">@color/aaps_theme_dark_primaryInverse</item>
+        <item name="toolbarStyle">@style/Widget.AAPS.Toolbar</item>
+        <item name="materialToolbarStyle">@style/Widget.AAPS.Toolbar</item>
+        <item name="materialAlertDialogTheme">@style/DialogTheme.Material3</item>
+        <item name="android:alertDialogTheme">@style/DialogTheme.Material3</item>
+        <item name="alertDialogTheme">@style/DialogTheme.Material3</item>
+    </style>
+
+    <style name="ThemeOverlay.AAPS.Material3.NoActionBar" parent="ThemeOverlay.AAPS.Material3">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="Widget.AAPS.Toolbar" parent="Widget.Material3.Toolbar">
+        <item name="android:background">?attr/colorPrimary</item>
+        <item name="titleTextColor">?attr/colorOnPrimary</item>
+        <item name="subtitleTextColor">?attr/colorOnPrimary</item>
+        <item name="titleTextAppearance">?attr/textAppearanceTitleLarge</item>
+        <item name="subtitleTextAppearance">?attr/textAppearanceTitleMedium</item>
+        <item name="android:theme">@style/ThemeOverlay.AAPS.Material3.NoActionBar</item>
+    </style>
+
+    <style name="DialogTheme.Material3" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="buttonBarNegativeButtonStyle">@style/DialogOkCancelButtonStyle</item>
+        <item name="buttonBarPositiveButtonStyle">@style/DialogOkCancelButtonStyle</item>
+        <item name="buttonBarNeutralButtonStyle">@style/DialogOkCancelButtonStyle</item>
+    </style>
+
+    <style name="AppTheme.Material3Overlay" parent="AppTheme">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.AAPS.Material3</item>
+    </style>
+
+    <style name="AppTheme.Material3Overlay.NoActionBar" parent="AppTheme.NoActionBar">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.AAPS.Material3</item>
+    </style>
+
+    <style name="AppTheme.Launcher.Material3" parent="AppTheme.Launcher">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.AAPS.Material3</item>
+    </style>
+
+</resources>

--- a/core/ui/src/main/res/values/styles.xml
+++ b/core/ui/src/main/res/values/styles.xml
@@ -386,15 +386,15 @@
     </style>
 
     <!-- Alert Dialogs -->
-    <style name="DialogTheme" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
+    <style name="DialogTheme" parent="DialogTheme.Material3">
         <item name="buttonBarNegativeButtonStyle">@style/DialogOkCancelButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/DialogOkCancelButtonStyle</item>
         <item name="dialogTitleBackground">@color/dialog_title_background</item>
         <item name="buttonBarNeutralButtonStyle">@style/DialogOkCancelButtonStyle</item>
     </style>
 
-    <style name="DialogOkCancelButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
-        <item name="android:textColor">@color/okButtonText</item>
+    <style name="DialogOkCancelButtonStyle" parent="Widget.Material3.Button.TextButton.Dialog">
+        <item name="android:textColor">?attr/colorPrimary</item>
     </style>
 
     <style name="AppThemeWarningDialog" parent="DialogTheme">

--- a/core/ui/src/main/res/values/theme_m3.xml
+++ b/core/ui/src/main/res/values/theme_m3.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.AAPS.Material3" parent="Theme.Material3.DayNight">
+        <item name="colorPrimary">@color/aaps_theme_light_primary</item>
+        <item name="colorOnPrimary">@color/aaps_theme_light_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/aaps_theme_light_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/aaps_theme_light_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/aaps_theme_light_secondary</item>
+        <item name="colorOnSecondary">@color/aaps_theme_light_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/aaps_theme_light_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/aaps_theme_light_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/aaps_theme_light_tertiary</item>
+        <item name="colorOnTertiary">@color/aaps_theme_light_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/aaps_theme_light_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/aaps_theme_light_onTertiaryContainer</item>
+        <item name="colorError">@color/aaps_theme_light_error</item>
+        <item name="colorOnError">@color/aaps_theme_light_onError</item>
+        <item name="colorErrorContainer">@color/aaps_theme_light_errorContainer</item>
+        <item name="colorOnErrorContainer">@color/aaps_theme_light_onErrorContainer</item>
+        <item name="colorBackground">@color/aaps_theme_light_background</item>
+        <item name="colorOnBackground">@color/aaps_theme_light_onBackground</item>
+        <item name="android:colorBackground">@color/aaps_theme_light_background</item>
+        <item name="colorSurface">@color/aaps_theme_light_surface</item>
+        <item name="colorOnSurface">@color/aaps_theme_light_onSurface</item>
+        <item name="colorSurfaceVariant">@color/aaps_theme_light_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/aaps_theme_light_onSurfaceVariant</item>
+        <item name="colorOutline">@color/aaps_theme_light_outline</item>
+        <item name="colorInverseSurface">@color/aaps_theme_light_inverseSurface</item>
+        <item name="colorInverseOnSurface">@color/aaps_theme_light_inverseOnSurface</item>
+        <item name="colorPrimaryInverse">@color/aaps_theme_light_primaryInverse</item>
+        <item name="android:windowBackground">@color/aaps_theme_light_background</item>
+        <item name="toolbarStyle">@style/Widget.AAPS.Toolbar</item>
+        <item name="materialToolbarStyle">@style/Widget.AAPS.Toolbar</item>
+        <item name="materialAlertDialogTheme">@style/DialogTheme.Material3</item>
+        <item name="android:alertDialogTheme">@style/DialogTheme.Material3</item>
+        <item name="alertDialogTheme">@style/DialogTheme.Material3</item>
+    </style>
+
+    <style name="Theme.AAPS.Material3.NoActionBar" parent="Theme.AAPS.Material3">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="ThemeOverlay.AAPS.Material3" parent="ThemeOverlay.Material3">
+        <item name="colorPrimary">@color/aaps_theme_light_primary</item>
+        <item name="colorOnPrimary">@color/aaps_theme_light_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/aaps_theme_light_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/aaps_theme_light_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/aaps_theme_light_secondary</item>
+        <item name="colorOnSecondary">@color/aaps_theme_light_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/aaps_theme_light_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/aaps_theme_light_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/aaps_theme_light_tertiary</item>
+        <item name="colorOnTertiary">@color/aaps_theme_light_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/aaps_theme_light_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/aaps_theme_light_onTertiaryContainer</item>
+        <item name="colorError">@color/aaps_theme_light_error</item>
+        <item name="colorOnError">@color/aaps_theme_light_onError</item>
+        <item name="colorErrorContainer">@color/aaps_theme_light_errorContainer</item>
+        <item name="colorOnErrorContainer">@color/aaps_theme_light_onErrorContainer</item>
+        <item name="colorBackground">@color/aaps_theme_light_background</item>
+        <item name="colorOnBackground">@color/aaps_theme_light_onBackground</item>
+        <item name="colorSurface">@color/aaps_theme_light_surface</item>
+        <item name="colorOnSurface">@color/aaps_theme_light_onSurface</item>
+        <item name="colorSurfaceVariant">@color/aaps_theme_light_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/aaps_theme_light_onSurfaceVariant</item>
+        <item name="colorOutline">@color/aaps_theme_light_outline</item>
+        <item name="colorInverseSurface">@color/aaps_theme_light_inverseSurface</item>
+        <item name="colorInverseOnSurface">@color/aaps_theme_light_inverseOnSurface</item>
+        <item name="colorPrimaryInverse">@color/aaps_theme_light_primaryInverse</item>
+        <item name="toolbarStyle">@style/Widget.AAPS.Toolbar</item>
+        <item name="materialToolbarStyle">@style/Widget.AAPS.Toolbar</item>
+        <item name="materialAlertDialogTheme">@style/DialogTheme.Material3</item>
+        <item name="android:alertDialogTheme">@style/DialogTheme.Material3</item>
+        <item name="alertDialogTheme">@style/DialogTheme.Material3</item>
+    </style>
+
+    <style name="ThemeOverlay.AAPS.Material3.NoActionBar" parent="ThemeOverlay.AAPS.Material3">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="Widget.AAPS.Toolbar" parent="Widget.Material3.Toolbar">
+        <item name="android:background">?attr/colorPrimary</item>
+        <item name="titleTextColor">?attr/colorOnPrimary</item>
+        <item name="subtitleTextColor">?attr/colorOnPrimary</item>
+        <item name="titleTextAppearance">?attr/textAppearanceTitleLarge</item>
+        <item name="subtitleTextAppearance">?attr/textAppearanceTitleMedium</item>
+        <item name="android:theme">@style/ThemeOverlay.AAPS.Material3.NoActionBar</item>
+    </style>
+
+    <style name="DialogTheme.Material3" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="buttonBarNegativeButtonStyle">@style/DialogOkCancelButtonStyle</item>
+        <item name="buttonBarPositiveButtonStyle">@style/DialogOkCancelButtonStyle</item>
+        <item name="buttonBarNeutralButtonStyle">@style/DialogOkCancelButtonStyle</item>
+    </style>
+
+    <style name="AppTheme.Material3Overlay" parent="AppTheme">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.AAPS.Material3</item>
+    </style>
+
+    <style name="AppTheme.Material3Overlay.NoActionBar" parent="AppTheme.NoActionBar">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.AAPS.Material3</item>
+    </style>
+
+    <style name="AppTheme.Launcher.Material3" parent="AppTheme.Launcher">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.AAPS.Material3</item>
+    </style>
+
+</resources>

--- a/plugins/sync/src/main/res/layout/activity_open_humans_login_new.xml
+++ b/plugins/sync/src/main/res/layout/activity_open_humans_login_new.xml
@@ -719,8 +719,8 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?colorSurface"
         android:elevation="4dp"
+        style="@style/Widget.AAPS.Toolbar"
         app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/pump/rileylink/src/main/res/layout/rileylink_status.xml
+++ b/pump/rileylink/src/main/res/layout/rileylink_status.xml
@@ -10,7 +10,8 @@
     <com.google.android.material.appbar.MaterialToolbar
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/appbar_padding_top">
+        android:paddingTop="@dimen/appbar_padding_top"
+        style="@style/Widget.AAPS.Toolbar">
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabLayout"

--- a/ui/src/main/res/layout/treatments_fragment.xml
+++ b/ui/src/main/res/layout/treatments_fragment.xml
@@ -9,7 +9,8 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:minHeight="?attr/actionBarSize" />
+        android:minHeight="?attr/actionBarSize"
+        style="@style/Widget.AAPS.Toolbar" />
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/treatments_tabs"


### PR DESCRIPTION
## Summary
- add Material 3 day/night theme resources and overlays that reuse the existing palette
- update shared dialog and toolbar styling to consume Material 3 color and typography attributes
- wire the launcher and a new `m3preview` flavor through the Material 3 overlay for opt-in testing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69082c22558483309dd1b658e11eb092